### PR TITLE
Fix shared vfc for non byoc

### DIFF
--- a/networking_generic_switch/devices/corsa_devices/__init__.py
+++ b/networking_generic_switch/devices/corsa_devices/__init__.py
@@ -442,28 +442,13 @@ class CorsaSwitch(devices.GenericSwitchDevice):
                 else:
                     uplink_ofport = int(str(segmentation_id)[-3:])
                     sharedNonByocVfc_tunnel = corsavfc.get_tunnel_by_bridge_and_ofport(headers, url_switch, sharedNonByocVFC, uplink_ofport)
-                    if str(uplink_port) == str(sharedNonByocVfc_tunnel): 
+                    if str(uplink_ofport) == str(sharedNonByocVfc_tunnel): 
                         br_id = sharedNonByocVFC
                     else:
                         LOG.info("PRUTH: plug_port_to_network - Network missing in sharedNonByocVFC")
  
-                    #br_id = sharedNonByocVFC
-
-                LOG.info("PRUTH: plug_port_to_network - BYOC br_id : " + str(br_id) + " for network " + str(segmentation_id))
+                LOG.info("PRUTH: plug_port_to_network - br_id : " + str(br_id) + " for network " + str(segmentation_id))
       
-                #if not br_id == None: 
-                #    LOG.info("PRUTH: plug_port_to_network - BYOC br_id : " + str(br_id) + " for network " + str(segmentation_id))
-                #else:     
-                #    uplink_ofport = int(str(segmentation_id)[-3:])
-                #    sharedNonByocVfc_tunnel = corsavfc.get_tunnel_by_bridge_and_ofport(headers, url_switch,
-                #                                                               sharedNonByocVFC, uplink_ofport)
-                #    LOG.info("PRUTH: plug_port_to_network - found sharedNonByocVfc_tunnel: " + str(sharedNonByocVfc_tunnel) + " for uplink_port: " + str(uplink_port) )
-
-                #    if not sharedNonByocVfc_tunnel == None:
-                #        br_id == sharedNonByocVFC
-                #        LOG.info("PRUTH: plug_port_to_network - NonBYOC  br_id : " + str(br_id) + " for network " + str(segmentation_id))
-
-
                 if port in self.config:
                     LOG.info("PRUTH: plug_port_to_network - Binding port " + str(port) + " maps to " + str(self.config[port]))
                     if br_id == sharedNonByocVFC:

--- a/networking_generic_switch/devices/corsa_devices/__init__.py
+++ b/networking_generic_switch/devices/corsa_devices/__init__.py
@@ -267,9 +267,6 @@ class CorsaSwitch(devices.GenericSwitchDevice):
 
         try:
             with ngs_lock.PoolLock(self.locker, **self.lock_kwargs):
-                ###c_br_descr = corsavfc.get_bridge_descr(headers, url_switch, c_br)
-                ###c_br_descr = c_br_descr + "-" + str(segmentation_id)
-                ###corsavfc.bridge_modify_descr(headers, url_switch , c_br, c_br_descr)
 
                 LOG.info("About to get_ofport: c_br: " + str(c_br) + ", c_uplink_ports: " + str(c_uplink_ports))
                 for uplink in c_uplink_ports.split(','):
@@ -282,10 +279,6 @@ class CorsaSwitch(devices.GenericSwitchDevice):
 
         except Exception as e:
             LOG.error("Failed add network. attempting to cleanup bridge: " + str(e) + ", " + traceback.format_exc())
-            ###try:
-            ###    output = corsavfc.bridge_delete(headers, url_switch, str(c_br))
-            ###except Exception as e2:
-            ###    LOG.error(" Failed to cleanup bridge after failed add_network: " + str(segmentation_id) + ", bridge: " + str(bridge) + ", Error: " + str(e2))
             raise e
 
 

--- a/networking_generic_switch/devices/corsa_devices/corsavfc.py
+++ b/networking_generic_switch/devices/corsa_devices/corsavfc.py
@@ -490,6 +490,30 @@ def get_bridge_controller(headers,
     return r
 
 #
+# GET TUNNELS ATTACHED TO BRIDGE 
+#
+#   200     
+#   403 Forbidden
+#   404 Not Found
+def get_bridge_tunnels(headers,
+                       url_switch,
+                       bridge_number=None,
+                       bridge_url=None):
+
+    if bridge_number and not bridge_url:
+        url = url_switch + ep_bridges + '/br' + str(bridge_number) + '/tunnels'
+    elif bridge_url and not bridge_number:
+        url = bridge_url + '/tunnels'
+    else:
+        return 404
+
+    try:
+        r = requests.get(url, headers=headers, verify=False)
+    except Exception as e:
+        raise e
+    return r
+
+#
 # GET INFO
 #
 #   200
@@ -554,6 +578,30 @@ def get_bridge_by_segmentation_id(headers,
 #
 #
 #
+# get_tunnel_by_bridge_and_ofport
+#
+# find tunnel for a given ofport on a bridge
+#
+def get_tunnel_by_bridge_and_ofport(headers,
+                                    url_switch,
+                                    bridge,
+                                    ofport):
+    if str(bridge)[:2] == 'br':
+        bridge_number = str(bridge)[2:]
+    else: 
+        bridge_number = str(bridge)
+    tunnels = get_bridge_tunnels(headers,url_switch,bridge_number)
+    links = tunnels.json()["links"]
+    for tunnel,value in links.items():
+        tunnel_url = value['href']
+        tunnel_ofport = value['tunnel']
+        if int(tunnel_ofport) == int(ofport):
+            return tunnel_ofport
+            LOG.info("--- PRUTH: get_tunnel_by_bridge_and_ofport - tunnel_ofport: " + str(tunnel_ofport))
+    return None
+#
+#
+#
 # get_bridge_by_vfc_name
 #
 # By convention we are putting the vfc_name in the "bridge-description" field
@@ -572,6 +620,8 @@ def get_bridge_by_vfc_name(headers,
             if bridge_descr.find(vfc_name) > -1 :
                 return bridge
     return None
+
+
 
 #
 # get_bridge_descr
@@ -596,7 +646,7 @@ def reclaim_ofport(headers,
     bridges = get_bridges(headers,url_switch)
 
     links=bridges.json()["links"]
-    LOG.info("PRUTH: bridges: " + str(links))
+    LOG.info("PRUTH: reclaim_ofport - bridges: " + str(links))
     for bridge,value in links.items():
         #bridge = 'br'+str(i)
         #bridgeInfo = get_bridge(headers,url_switch,bridges[bridge])

--- a/networking_generic_switch/devices/corsa_devices/corsavfc.py
+++ b/networking_generic_switch/devices/corsa_devices/corsavfc.py
@@ -597,7 +597,6 @@ def get_tunnel_by_bridge_and_ofport(headers,
         tunnel_ofport = value['tunnel']
         if int(tunnel_ofport) == int(ofport):
             return tunnel_ofport
-            LOG.info("--- PRUTH: get_tunnel_by_bridge_and_ofport - tunnel_ofport: " + str(tunnel_ofport))
     return None
 #
 #


### PR DESCRIPTION
These are the changes for usage of bridge-descr field on Corsa VFCs. 
- VFCs for BYOC neutron networks have the segmentation id (vlan-tag) appended to the bridge-descr field.
- Shared VFC for nonBYOC physnet1 networks will not have the segmentation id appended to the bridge-descr. Uplink tunnel will be attached on creation of network. Search for the existing networks on shared VFC will be executed based on the uplink tunnels.   