### PR TITLE
fix l2-only ports

### DIFF
--- a/networking_generic_switch/generic_switch_mech.py
+++ b/networking_generic_switch/generic_switch_mech.py
@@ -31,6 +31,10 @@ GENERIC_SWITCH_ENTITY = 'GENERICSWITCH'
 
 class GenericSwitchDriver(api.MechanismDriver):
 
+    @property
+    def connectivity(self):
+        return portbindings.CONNECTIVITY_L2
+    
     def initialize(self):
         """Perform driver initialization.
 


### PR DESCRIPTION
set "connectivity" property to comply with updated mechanism driver spec. See https://github.com/openstack/neutron-lib/commit/c2166f9af6ccbe8fdaff6fc035291633539329dc

referencing change ID I5730c68e4e860028efa0541b0098c439c14524d7