### PR TITLE
2023.1 backport: Allow reusing ssh connections

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -273,6 +273,16 @@ to each device to one, but the number may be configured per-device as follows::
     [genericswitch:device-hostname]
     ngs_max_connections = <max connections>
 
+To reduce SSH connection setup overhead, SSH connection reuse may also be
+enabled per-device::
+
+    [genericswitch:device-hostname]
+    ngs_ssh_reuse_connection = True
+
+Connection reuse is only supported when ``ngs_max_connections = 1``. If
+``ngs_max_connections`` is greater than one, connection reuse is disabled and
+networking-generic-switch logs a warning during device initialisation.
+
 When synchronization is used, each Neutron thread executing the
 networking-generic-switch plugin will attempt to acquire a lock, with a default
 timeout of 60 seconds before failing. This timeout can be configured as follows

--- a/networking_generic_switch/devices/__init__.py
+++ b/networking_generic_switch/devices/__init__.py
@@ -37,6 +37,7 @@ NGS_INTERNAL_OPTS = [
     {'name': 'ngs_ssh_disabled_algorithms'},
     {'name': 'ngs_ssh_connect_timeout', 'default': 60},
     {'name': 'ngs_ssh_connect_interval', 'default': 10},
+    {'name': 'ngs_ssh_reuse_connection', 'default': False},
     {'name': 'ngs_max_connections', 'default': 1},
     {'name': 'ngs_switchport_mode', 'default': 'access'},
     # If True, disable switch ports that are not in use.
@@ -165,6 +166,11 @@ class GenericSwitchDevice(object, metaclass=abc.ABCMeta):
         """Return whether to batch up requests to the switch."""
         return strutils.bool_from_string(
             self.ngs_config['ngs_batch_requests'])
+
+    def _reuse_connection_enabled(self):
+        """Return whether to reuse ssh connections."""
+        return strutils.bool_from_string(
+            self.ngs_config['ngs_ssh_reuse_connection'])
 
     @abc.abstractmethod
     def add_network(self, segmentation_id, network_id):

--- a/networking_generic_switch/devices/netmiko_devices/__init__.py
+++ b/networking_generic_switch/devices/netmiko_devices/__init__.py
@@ -154,13 +154,15 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
         self._should_reuse_connection = False
         if self._reuse_connection_enabled():
             if int(self.ngs_config['ngs_max_connections']) > 1:
-                LOG.warning("Max connections > 1, not enabling connection reuse.")
+                LOG.warning("Max connections > 1, not enabling connection "
+                            "reuse.")
             else:
                 self._should_reuse_connection = True
                 self._cached_connection = None
                 self._cached_connection_lock = threading.Lock()
                 self._ssh_session_lock = threading.Lock()
-                # we don't clean up per command now, make sure we clean up on exit
+                # we don't clean up per command now, make sure we clean up on
+                # exit
                 atexit.register(self._invalidate_cached_connection)
 
     def _format_commands(self, commands, **kwargs):
@@ -281,9 +283,9 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
             except Exception as error:
                 self._invalidate_cached_connection()
                 LOG.warning(
-                    _("Retrying switch command execution with "
+                    "Retrying switch command execution with "
                     "a clean SSH connection for device: "
-                    "%(device)s, error: %(error)s"), {
+                    "%(device)s, error: %(error)s", {
                         'device': device_utils.sanitise_config(self.config),
                         'error': error})
             try:

--- a/networking_generic_switch/devices/netmiko_devices/__init__.py
+++ b/networking_generic_switch/devices/netmiko_devices/__init__.py
@@ -15,6 +15,7 @@
 import atexit
 import contextlib
 import functools
+import threading
 import uuid
 
 import netmiko
@@ -52,7 +53,12 @@ def check_output(operation):
                 an error has occurred.
             """
             output = func(self, *args, **kwargs)
-            self.check_output(output, operation)
+            try:
+                self.check_output(output, operation)
+            except exc.GenericSwitchNetmikoConfigError:
+                # Raised if ERROR_MSG_PATTERNS catches an output error
+                self._invalidate_cached_connection()
+                raise
             return output
 
         return wrapper
@@ -145,6 +151,18 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
             self.locker.start()
             atexit.register(self.locker.stop)
 
+        self._should_reuse_connection = False
+        if self._reuse_connection_enabled():
+            if int(self.ngs_config['ngs_max_connections']) > 1:
+                LOG.warning("Max connections > 1, not enabling connection reuse.")
+            else:
+                self._should_reuse_connection = True
+                self._cached_connection = None
+                self._cached_connection_lock = threading.Lock()
+                self._ssh_session_lock = threading.Lock()
+                # we don't clean up per command now, make sure we clean up on exit
+                atexit.register(self._invalidate_cached_connection)
+
     def _format_commands(self, commands, **kwargs):
         if not commands:
             return []
@@ -185,9 +203,29 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
         def _create_connection():
             return netmiko.ConnectHandler(**self.config)
 
+        def _get_or_create_connection():
+            with self._cached_connection_lock:
+                if self._cached_connection is None:
+                    self._cached_connection = _create_connection()
+                elif not self._cached_connection.is_alive():
+                    try:
+                        self._cached_connection.disconnect()
+                    except Exception:
+                        LOG.debug(
+                            "Failed to close stale SSH connection",
+                            exc_info=True,
+                        )
+                    finally:
+                        self._cached_connection = None
+                    self._cached_connection = _create_connection()
+                return self._cached_connection
+
         # First, create a connection.
         try:
-            net_connect = _create_connection()
+            if self._should_reuse_connection:
+                net_connect = _get_or_create_connection()
+            else:
+                net_connect = _create_connection()
         except tenacity.RetryError as e:
             LOG.error("Reached maximum SSH connection attempts, not retrying")
             raise exc.GenericSwitchNetmikoConnectError(
@@ -198,8 +236,26 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
                 config=device_utils.sanitise_config(self.config), error=e)
 
         # Now yield the connection to the caller.
-        with net_connect:
+        if self._should_reuse_connection:
             yield net_connect
+        else:
+            with net_connect:
+                yield net_connect
+
+    def _invalidate_cached_connection(self):
+        if not getattr(self, '_cached_connection', None):
+            return
+
+        with self._cached_connection_lock:
+            try:
+                self._cached_connection.disconnect()
+            except Exception:
+                LOG.debug(
+                    "Failed to close cached SSH connection",
+                    exc_info=True,
+                )
+            finally:
+                self._cached_connection = None
 
     def send_commands_to_device(self, cmd_set):
         if not cmd_set:
@@ -209,7 +265,32 @@ class NetmikoSwitch(devices.GenericSwitchDevice):
         # If configured, batch up requests to the switch
         if self.batch_cmds is not None:
             return self.batch_cmds.do_batch(self, cmd_set)
+
+        # If configured, use cached ssh connection with 1 retry
+        if self._should_reuse_connection:
+            return self._cached_send_commands_to_device(cmd_set)
+
         return self._send_commands_to_device(cmd_set)
+
+    def _cached_send_commands_to_device(self, cmd_set):
+        # because the cached connection might be "dirty", add one retry.
+
+        with self._ssh_session_lock:
+            try:
+                return self._send_commands_to_device(cmd_set)
+            except Exception as error:
+                self._invalidate_cached_connection()
+                LOG.warning(
+                    _("Retrying switch command execution with "
+                    "a clean SSH connection for device: "
+                    "%(device)s, error: %(error)s"), {
+                        'device': device_utils.sanitise_config(self.config),
+                        'error': error})
+            try:
+                return self._send_commands_to_device(cmd_set)
+            except Exception:
+                self._invalidate_cached_connection()
+                raise
 
     def _send_commands_to_device(self, cmd_set):
         try:

--- a/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_netmiko_base.py
@@ -23,6 +23,7 @@ import paramiko
 import tenacity
 from tooz import coordination
 
+from networking_generic_switch import batching
 from networking_generic_switch.devices import netmiko_devices
 from networking_generic_switch.devices import utils
 from networking_generic_switch import exceptions as exc
@@ -55,6 +56,50 @@ class TestNetmikoSwitch(NetmikoSwitchTestBase):
         self.assertRaisesRegex(
             Exception, "backend_url",
             self._make_switch_device, {'ngs_batch_requests': True})
+
+    @mock.patch.object(netmiko, 'ConnectHandler', autospec=True)
+    def test_batch_reuses_connection_across_subsequent_batches(
+            self, m_conn_handler):
+        self.cfg.config(backend_url='url', group='ngs_coordination')
+        switch = self._make_switch_device({
+            'ngs_batch_requests': True,
+            'ngs_ssh_reuse_connection': True,
+        })
+        switch.batch_cmds = batching.SwitchBatch(
+            switch_name='host', switch_queue=mock.Mock())
+        connection = mock.MagicMock(netmiko.base_connection.BaseConnection)
+        m_conn_handler.return_value = connection
+
+        lock = mock.MagicMock()
+        switch.batch_cmds._send_commands(switch, [{'cmds': ['cmd1']}], lock)
+        switch.batch_cmds._send_commands(switch, [{'cmds': ['cmd2']}], lock)
+
+        self.assertEqual(1, m_conn_handler.call_count)
+
+    @mock.patch.object(netmiko, 'ConnectHandler', autospec=True)
+    def test_batch_replaces_dead_connection_across_subsequent_batches(
+            self, m_conn_handler):
+        self.cfg.config(backend_url='url', group='ngs_coordination')
+        switch = self._make_switch_device({
+            'ngs_batch_requests': True,
+            'ngs_ssh_reuse_connection': True,
+        })
+        switch.batch_cmds = batching.SwitchBatch(
+            switch_name='host', switch_queue=mock.Mock())
+        first_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        second_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        first_connection.is_alive.return_value = False
+        m_conn_handler.side_effect = [first_connection, second_connection]
+
+        lock = mock.MagicMock()
+        switch.batch_cmds._send_commands(switch, [{'cmds': ['cmd1']}], lock)
+        switch.batch_cmds._send_commands(switch, [{'cmds': ['cmd2']}], lock)
+
+        self.assertEqual(2, m_conn_handler.call_count)
+        first_connection.disconnect.assert_called_once_with()
+        second_connection.disconnect.assert_not_called()
 
     @mock.patch('networking_generic_switch.devices.netmiko_devices.'
                 'NetmikoSwitch.send_commands_to_device',
@@ -267,6 +312,148 @@ class TestNetmikoSwitch(NetmikoSwitchTestBase):
         self.assertFalse(connect_mock.send_config_set.called)
         self.assertFalse(connect_mock.send_command.called)
 
+    @mock.patch.object(netmiko, 'ConnectHandler', autospec=True)
+    def test_send_commands_to_device_reuses_cached_connection(
+            self, m_conn_handler):
+        switch = self._make_switch_device({
+            'ngs_ssh_reuse_connection': True,
+        })
+        connection = mock.MagicMock(netmiko.base_connection.BaseConnection)
+        m_conn_handler.return_value = connection
+
+        switch.send_commands_to_device(['cmd1'])
+        switch.send_commands_to_device(['cmd2'])
+        self.assertEqual(1, m_conn_handler.call_count)
+
+    @mock.patch.object(netmiko, 'ConnectHandler', autospec=True)
+    def test_send_commands_to_device_ignores_reuse_when_max_connections_gt_1(
+            self, m_conn_handler):
+        switch = self._make_switch_device({
+            'ngs_ssh_reuse_connection': True,
+            'ngs_max_connections': 2,
+        })
+        first_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        second_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        m_conn_handler.side_effect = [first_connection, second_connection]
+
+        switch.send_commands_to_device(['cmd1'])
+        switch.send_commands_to_device(['cmd2'])
+
+        self.assertEqual(2, m_conn_handler.call_count)
+
+    @mock.patch.object(netmiko, 'ConnectHandler', autospec=True)
+    def test_send_commands_to_device_reused_connection_not_closed_per_call(
+            self, m_conn_handler):
+        switch = self._make_switch_device({
+            'ngs_ssh_reuse_connection': True,
+        })
+        connection = mock.MagicMock(netmiko.base_connection.BaseConnection)
+        m_conn_handler.return_value = connection
+
+        switch.send_commands_to_device(['cmd1'])
+        switch.send_commands_to_device(['cmd2'])
+
+        connection.__exit__.assert_not_called()
+
+    @mock.patch.object(netmiko, 'ConnectHandler', autospec=True)
+    def test_send_commands_to_device_does_not_share_cached_connection(
+            self, m_conn_handler):
+        switch1 = self._make_switch_device({
+            'ngs_ssh_reuse_connection': True,
+        })
+        switch2 = self._make_switch_device({
+            'ngs_ssh_reuse_connection': True,
+        })
+        first_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        second_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        m_conn_handler.side_effect = [first_connection, second_connection]
+
+        switch1.send_commands_to_device(['cmd1'])
+        switch2.send_commands_to_device(['cmd1'])
+
+        self.assertEqual(2, m_conn_handler.call_count)
+
+    @mock.patch.object(netmiko, 'ConnectHandler', autospec=True)
+    def test_send_commands_to_device_replaces_dead_cached_connection(
+            self, m_conn_handler):
+        switch = self._make_switch_device({
+            'ngs_ssh_reuse_connection': True,
+        })
+        first_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        second_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        first_connection.is_alive.return_value = False
+        m_conn_handler.side_effect = [first_connection, second_connection]
+
+        switch.send_commands_to_device(['cmd1'])
+        switch.send_commands_to_device(['cmd2'])
+
+        self.assertEqual(2, m_conn_handler.call_count)
+        first_connection.disconnect.assert_called_once_with()
+        second_connection.disconnect.assert_not_called()
+
+    @mock.patch.object(netmiko, 'ConnectHandler', autospec=True)
+    @mock.patch.object(netmiko_devices.NetmikoSwitch, 'send_config_set',
+                       autospec=True)
+    @mock.patch.object(netmiko_devices.NetmikoSwitch, 'save_configuration',
+                       autospec=True)
+    def test_send_commands_to_device_retries_cached_connection_failure(
+            self, save_mock, send_mock, m_conn_handler):
+        switch = self._make_switch_device({
+            'ngs_ssh_reuse_connection': True,
+        })
+        first_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        second_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        m_conn_handler.side_effect = [first_connection, second_connection]
+        send_mock.side_effect = [Exception("stale shell"), "fake output"]
+
+        output = switch.send_commands_to_device(['cmd1'])
+
+        self.assertEqual("fake output", output)
+        self.assertEqual(2, m_conn_handler.call_count)
+        send_mock.assert_has_calls([
+            mock.call(switch, first_connection, ['cmd1']),
+            mock.call(switch, second_connection, ['cmd1'])
+        ])
+        first_connection.disconnect.assert_called_once_with()
+        second_connection.disconnect.assert_not_called()
+        save_mock.assert_called_once_with(switch, second_connection)
+
+    @mock.patch.object(netmiko, 'ConnectHandler', autospec=True)
+    @mock.patch.object(netmiko_devices.NetmikoSwitch, 'send_config_set',
+                       autospec=True)
+    @mock.patch.object(netmiko_devices.NetmikoSwitch, 'save_configuration',
+                       autospec=True)
+    def test_send_commands_to_device_second_failure_raises(
+            self, save_mock, send_mock, m_conn_handler):
+        switch = self._make_switch_device({
+            'ngs_ssh_reuse_connection': True,
+        })
+        first_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        second_connection = mock.MagicMock(
+            netmiko.base_connection.BaseConnection)
+        m_conn_handler.side_effect = [first_connection, second_connection]
+        send_mock.side_effect = [Exception("stale shell"),
+                                 Exception("stale shell again")]
+
+        self.assertRaises(
+            exc.GenericSwitchNetmikoConnectError,
+            switch.send_commands_to_device,
+            ['cmd1'])
+        self.assertEqual(2, m_conn_handler.call_count)
+        self.assertEqual(2, send_mock.call_count)
+        first_connection.disconnect.assert_called_once_with()
+        second_connection.disconnect.assert_called_once_with()
+        save_mock.assert_not_called()
+
     @mock.patch.object(netmiko_devices.NetmikoSwitch, '_get_connection')
     @mock.patch.object(netmiko_devices.NetmikoSwitch, 'send_config_set')
     @mock.patch.object(netmiko_devices.NetmikoSwitch, 'save_configuration')
@@ -293,6 +480,32 @@ class TestNetmikoSwitch(NetmikoSwitchTestBase):
         send_mock.assert_called_once_with(connect_mock, ['spam ham aaaa'])
         self.assertEqual('fake output', result)
         save_mock.assert_not_called()
+
+    @mock.patch.object(netmiko_devices.NetmikoSwitch,
+                       '_invalidate_cached_connection', autospec=True)
+    @mock.patch.object(netmiko_devices.NetmikoSwitch,
+                       'check_output',
+                       side_effect=exc.GenericSwitchNetmikoConfigError(),
+                       autospec=True)
+    @mock.patch.object(netmiko_devices.NetmikoSwitch,
+                       'send_commands_to_device',
+                       return_value='fake output',
+                       autospec=True)
+    def test_check_output_failure_invalidates_cached_connection(
+            self, send_mock, check_mock, invalidate_mock):
+        switch = self._make_switch_device({
+            'ngs_ssh_reuse_connection': True,
+        })
+
+        self.assertRaises(
+            exc.GenericSwitchNetmikoConfigError,
+            switch.add_network,
+            22,
+            '0ae071f5-5be9-43e4-80ea-e41fefe85b21')
+        send_mock.assert_called_once()
+        check_mock.assert_called_once_with(
+            switch, 'fake output', 'add network')
+        invalidate_mock.assert_called_once_with(switch)
 
     def test_send_config_set(self):
         connect_mock = mock.MagicMock(netmiko.base_connection.BaseConnection)

--- a/networking_generic_switch/tests/unit/test_devices.py
+++ b/networking_generic_switch/tests/unit/test_devices.py
@@ -114,6 +114,7 @@ class TestDeviceManager(unittest.TestCase):
                       "ngs_mac_address": 'aa:bb:cc:dd:ee:ff',
                       "ngs_ssh_connect_timeout": "120",
                       "ngs_ssh_connect_interval": "20",
+                      "ngs_ssh_reuse_connection": "true",
                       "ngs_trunk_ports": "port1,port2",
                       "ngs_physical_networks": "physnet1,physnet2",
                       "ngs_port_default_vlan": "20",
@@ -124,6 +125,7 @@ class TestDeviceManager(unittest.TestCase):
         self.assertNotIn('ngs_mac_address', device.config)
         self.assertNotIn('ngs_ssh_connect_timeout', device.config)
         self.assertNotIn('ngs_ssh_connect_interval', device.config)
+        self.assertNotIn('ngs_ssh_reuse_connection', device.config)
         self.assertNotIn('ngs_trunk_ports', device.config)
         self.assertNotIn('ngs_physical_networks', device.config)
         self.assertNotIn('ngs_port_default_vlan', device.config)
@@ -131,6 +133,7 @@ class TestDeviceManager(unittest.TestCase):
                          device.ngs_config['ngs_mac_address'])
         self.assertEqual('120', device.ngs_config['ngs_ssh_connect_timeout'])
         self.assertEqual('20', device.ngs_config['ngs_ssh_connect_interval'])
+        self.assertEqual('true', device.ngs_config['ngs_ssh_reuse_connection'])
         self.assertEqual('port1,port2', device.ngs_config['ngs_trunk_ports'])
         self.assertEqual('physnet1,physnet2',
                          device.ngs_config['ngs_physical_networks'])
@@ -147,6 +150,7 @@ class TestDeviceManager(unittest.TestCase):
         self.assertNotIn('ngs_mac_address', device.ngs_config)
         self.assertEqual(60, device.ngs_config['ngs_ssh_connect_timeout'])
         self.assertEqual(10, device.ngs_config['ngs_ssh_connect_interval'])
+        self.assertFalse(device.ngs_config['ngs_ssh_reuse_connection'])
         self.assertNotIn('ngs_trunk_ports', device.ngs_config)
         self.assertNotIn('ngs_physical_networks', device.ngs_config)
         self.assertNotIn('ngs_port_default_vlan', device.ngs_config)

--- a/releasenotes/notes/add-ssh-connection-reuse-hash.yaml
+++ b/releasenotes/notes/add-ssh-connection-reuse-hash.yaml
@@ -1,0 +1,10 @@
+---
+features:
+  - |
+    Adds support for reusing ssh connections, instead of creating a new one for
+    each command. This is useful with switches that take a long time to initiate
+    new connections, particularly Dell OS10.
+
+    It's configured per-switch with the `ngs_ssh_reuse_connection` option, and
+    defaults to False. It can be used with batching, but will be disabled if
+    `ngs_max_connections` > 1.


### PR DESCRIPTION
Instead of opening a new connection each time, allow caching them for reuse. On switches that take a long time to initiate a new connection, this greatly improves speed, even with batching enabled.

For simplicity, a guard ensures that connection reuse is disabled when ngs_max_connections > 1. Future work could use a pool of cached connections instead of just one.

Cherry-Picked from 596c2e8f77d5c519bd716bcb62f8035890813ece
Change-Id: I2cc97adfb55c49cae84da1840c38966600f5ae89