### PR TITLE
reset switchport instead of trying to remove specific vlan

### DIFF
--- a/networking_generic_switch/devices/netmiko_devices/dell.py
+++ b/networking_generic_switch/devices/netmiko_devices/dell.py
@@ -104,8 +104,9 @@ class DellNos(netmiko_devices.NetmikoSwitch):
     )
 
     DELETE_PORT = (
-        'interface vlan {segmentation_id}',
-        'no untagged {port}',
+        'interface {port}',
+        'no switchport',
+        'switchport',
         'exit',
     )
 

--- a/networking_generic_switch/tests/unit/netmiko/test_dell.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_dell.py
@@ -84,7 +84,7 @@ class TestNetmikoDellNos(test_netmiko_base.NetmikoSwitchTestBase):
     def test_delete_port(self, mock_exec):
         self.switch.delete_port(3333, 33)
         mock_exec.assert_called_with(
-            ['interface vlan 33', 'no untagged 3333', 'exit'])
+            ['interface 3333', 'no switchport', 'switchport', 'exit'])
 
     def test_check_output(self):
         self.switch.check_output('fake output', 'fake op')
@@ -127,7 +127,7 @@ tagged fake-port
             port=3333,
             segmentation_id=33)
         self.assertEqual(cmd_set,
-                         ['interface vlan 33', 'no untagged 3333', 'exit'])
+                         ['interface 3333', 'no switchport', 'switchport', 'exit'])
 
         cmd_set = self.switch._format_commands(
             dell.DellNos.ADD_NETWORK_TO_TRUNK,


### PR DESCRIPTION
Dell OS9 assigns ports to vlans, instead of vlans to ports. This makes removing a port from a vlan tricky, as you need to know which one it's currently on.

Instead, toggle the port into L3 mode then back to L2 to clear all vlan assignments (and all other L2 config).|
Since this is used in "delete port", this *should* be ok, but is worth verifying.

Change-Id: Ib274516c093eef142b188a1dfadd4b93440cfcdf (cherry picked from commit f721698fa60f3ffa4a06a666eac331d6b2ea84ea)