### PR TITLE
hack: allow forcing ports to trunk mode to enable in-band bmc

### DIFF
--- a/doc/source/configuration.rst
+++ b/doc/source/configuration.rst
@@ -408,6 +408,64 @@ because the agent needs access to all active VLANs.
 
 Note that this option is only used if ``ngs_manage_vlans = True``.
 
+Trunk-native ports (Dell OS10 only)
+===================================
+
+Some baremetal deployments share a single physical port between in-band
+tenant traffic and out-of-band BMC management traffic, with the BMC reachable
+on a dedicated tagged VLAN. The desired end-state on each such port is:
+
+* the port is in trunk mode,
+* the tenant VLAN arrives untagged (set as the trunk's native VLAN),
+* the BMC OOB VLAN arrives tagged (present on the trunk allowed list).
+
+By default, Networking Generic Switch re-asserts ``switchport mode access``
+on every port bind, which would wipe the trunk configuration and drop the
+BMC. To opt specific ports out of that behaviour, list them under
+``ngs_trunk_native_ports``::
+
+    [genericswitch:dell-tor-1]
+    device_type = netmiko_dell_os10
+    ip = <switch mgmt ip address>
+    username = admin
+    password = password
+    ngs_trunk_native_ports = ethernet1/1/7, ethernet1/1/8
+
+For ports in this list, ``plug_port_to_network`` emits trunk mode plus the
+tenant VLAN as the native VLAN::
+
+    interface ethernet1/1/7
+      switchport mode trunk
+      switchport access vlan <tenant_segmentation_id>
+      exit
+
+``delete_port`` clears only the native VLAN, leaving trunk mode and the
+allowed-VLAN list intact so the BMC stays reachable across rebinds.
+
+The operator must pre-configure each listed port out of band with the trunk
+allowed list (and the OOB VLAN itself), since neither is tracked by
+Networking Generic Switch::
+
+    interface ethernet1/1/7
+      switchport trunk allowed vlan 100        ! the BMC OOB VLAN
+      no shutdown
+
+Caveats:
+
+* This option is consumed only by the Dell OS10 driver. Listing ports here
+  on any other driver is silently ignored — the default access-mode
+  template will still fire and wipe the trunk config. There is no startup
+  validation.
+* Port identifiers must match exactly what Ironic sends in
+  ``local_link_connection/port_id`` (case, whitespace, format). A mismatch
+  silently falls back to the default access-mode template and drops the
+  BMC.
+* The OOB VLAN itself is not tracked by Networking Generic Switch — it
+  must exist on the switch (``interface vlan <oob>``) before deployment.
+* A port should not appear in both ``ngs_trunk_ports`` and
+  ``ngs_trunk_native_ports``; the two features have incompatible
+  semantics.
+
 .. _physicalnetworks:
 
 Multiple physical networks

--- a/networking_generic_switch/devices/__init__.py
+++ b/networking_generic_switch/devices/__init__.py
@@ -29,6 +29,10 @@ NGS_INTERNAL_OPTS = [
     {'name': 'ngs_mac_address'},
     # Comma-separated list of names of interfaces to be added to each network.
     {'name': 'ngs_trunk_ports'},
+    # Comma-separated list of interfaces to be configured as 'hybrid'
+    # tenant networks will be untagged as usual, but preserves manually trunked
+    # tagged vlans, such as for BMC access.
+    {'name': 'ngs_trunk_native_ports'},
     {'name': 'ngs_port_default_vlan'},
     # Comma-separated list of physical networks to which this switch is mapped.
     {'name': 'ngs_physical_networks'},
@@ -113,6 +117,15 @@ class GenericSwitchDevice(object, metaclass=abc.ABCMeta):
         if not trunk_ports:
             return []
         return [port.strip() for port in trunk_ports.split(',')]
+
+    def _get_trunk_native_ports(self):
+        """Return a list of pre-configured trunk ports whose native VLAN
+        is set per-bind by plug_port_to_network. See ngs_trunk_native_ports.
+        """
+        ports = self.ngs_config.get('ngs_trunk_native_ports')
+        if not ports:
+            return []
+        return [port.strip() for port in ports.split(',')]
 
     def _get_port_default_vlan(self):
         """Return a default vlan of switch's interface if you specify."""

--- a/networking_generic_switch/devices/netmiko_devices/dell.py
+++ b/networking_generic_switch/devices/netmiko_devices/dell.py
@@ -95,30 +95,30 @@ class DellOS10(netmiko_devices.NetmikoSwitch):
     def plug_port_to_network(self, port, segmentation_id):
         if port not in self._get_trunk_native_ports():
             return super().plug_port_to_network(port, segmentation_id)
-        
+
         # trunk-native hack
         LOG.info("Trunk-native port %s: assert trunk mode, native vlan -> %s",
                  port, segmentation_id)
         cmds = self._format_commands(
             self.PLUG_PORT_TO_NETWORK_TRUNK_NATIVE,
-            port=port, 
+            port=port,
             segmentation_id=segmentation_id
-            )
+        )
         return self.send_commands_to_device(cmds)
 
     @netmiko_devices.check_output('unplug port')
     def delete_port(self, port, segmentation_id):
         if port not in self._get_trunk_native_ports():
             return super().delete_port(port, segmentation_id)
-        
+
         # trunk-native hack
         # warning! ignores `ngs_port_default_vlan` and `_disable_inactive_ports`
         LOG.info("Trunk-native port %s: clear native vlan, keep trunk", port)
         cmds = self._format_commands(
             self.DELETE_PORT,
-            port=port, 
+            port=port,
             segmentation_id=segmentation_id
-            )
+        )
         return self.send_commands_to_device(cmds)
 
 

--- a/networking_generic_switch/devices/netmiko_devices/dell.py
+++ b/networking_generic_switch/devices/netmiko_devices/dell.py
@@ -14,8 +14,12 @@
 
 import re
 
+from oslo_log import log as logging
+
 from networking_generic_switch import exceptions as exc
 from networking_generic_switch.devices import netmiko_devices
+
+LOG = logging.getLogger(__name__)
 
 
 class DellOS10(netmiko_devices.NetmikoSwitch):
@@ -35,6 +39,14 @@ class DellOS10(netmiko_devices.NetmikoSwitch):
     PLUG_PORT_TO_NETWORK = (
         "interface {port}",
         "switchport mode access",
+        "switchport access vlan {segmentation_id}",
+        "exit",
+    )
+
+    # Hybrid port mode, untagged access vlan but preserve existing trunks
+    PLUG_PORT_TO_NETWORK_TRUNK_NATIVE = (
+        "interface {port}",
+        "switchport mode trunk",
         "switchport access vlan {segmentation_id}",
         "exit",
     )
@@ -78,6 +90,33 @@ class DellOS10(netmiko_devices.NetmikoSwitch):
     Sequence of re.RegexObject objects representing patterns to check for in
     device output that indicate a failure to apply configuration.
     """
+
+    @netmiko_devices.check_output('plug port')
+    def plug_port_to_network(self, port, segmentation_id):
+        if port not in self._get_trunk_native_ports():
+            return super(DellOS10, self).plug_port_to_network(
+                port, segmentation_id)
+        LOG.info("Port %s is configured as a trunk-native port; asserting "
+                 "trunk mode and setting native vlan %s.",
+                 port, segmentation_id)
+        cmds = self._format_commands(
+            self.PLUG_PORT_TO_NETWORK_TRUNK_NATIVE,
+            port=port,
+            segmentation_id=segmentation_id)
+        return self.send_commands_to_device(cmds)
+
+    @netmiko_devices.check_output('unplug port')
+    def delete_port(self, port, segmentation_id):
+        if port not in self._get_trunk_native_ports():
+            return super(DellOS10, self).delete_port(port, segmentation_id)
+        LOG.info("Port %s is configured as a trunk-native port; clearing "
+                 "native vlan only, leaving trunk mode and allowed vlans "
+                 "intact.", port)
+        cmds = self._format_commands(
+            self.DELETE_PORT,
+            port=port,
+            segmentation_id=segmentation_id)
+        return self.send_commands_to_device(cmds)
 
 
 class DellNos(netmiko_devices.NetmikoSwitch):

--- a/networking_generic_switch/devices/netmiko_devices/dell.py
+++ b/networking_generic_switch/devices/netmiko_devices/dell.py
@@ -91,33 +91,35 @@ class DellOS10(netmiko_devices.NetmikoSwitch):
     device output that indicate a failure to apply configuration.
     """
 
-    @netmiko_devices.check_output('plug port')
     def plug_port_to_network(self, port, segmentation_id):
         if port not in self._get_trunk_native_ports():
             return super().plug_port_to_network(port, segmentation_id)
+        return self._plug_port_trunk_native(port, segmentation_id)
 
-        # trunk-native hack
+    @netmiko_devices.check_output('plug port')
+    def _plug_port_trunk_native(self, port, segmentation_id):
         LOG.info("Trunk-native port %s: assert trunk mode, native vlan -> %s",
                  port, segmentation_id)
         cmds = self._format_commands(
             self.PLUG_PORT_TO_NETWORK_TRUNK_NATIVE,
             port=port,
-            segmentation_id=segmentation_id
+            segmentation_id=segmentation_id,
         )
         return self.send_commands_to_device(cmds)
 
-    @netmiko_devices.check_output('unplug port')
     def delete_port(self, port, segmentation_id):
         if port not in self._get_trunk_native_ports():
             return super().delete_port(port, segmentation_id)
+        return self._delete_port_trunk_native(port, segmentation_id)
 
-        # trunk-native hack
+    @netmiko_devices.check_output('unplug port')
+    def _delete_port_trunk_native(self, port, segmentation_id):
         # warning! ignores `ngs_port_default_vlan` and `_disable_inactive_ports`
         LOG.info("Trunk-native port %s: clear native vlan, keep trunk", port)
         cmds = self._format_commands(
             self.DELETE_PORT,
             port=port,
-            segmentation_id=segmentation_id
+            segmentation_id=segmentation_id,
         )
         return self.send_commands_to_device(cmds)
 

--- a/networking_generic_switch/devices/netmiko_devices/dell.py
+++ b/networking_generic_switch/devices/netmiko_devices/dell.py
@@ -94,28 +94,31 @@ class DellOS10(netmiko_devices.NetmikoSwitch):
     @netmiko_devices.check_output('plug port')
     def plug_port_to_network(self, port, segmentation_id):
         if port not in self._get_trunk_native_ports():
-            return super(DellOS10, self).plug_port_to_network(
-                port, segmentation_id)
-        LOG.info("Port %s is configured as a trunk-native port; asserting "
-                 "trunk mode and setting native vlan %s.",
+            return super().plug_port_to_network(port, segmentation_id)
+        
+        # trunk-native hack
+        LOG.info("Trunk-native port %s: assert trunk mode, native vlan -> %s",
                  port, segmentation_id)
         cmds = self._format_commands(
             self.PLUG_PORT_TO_NETWORK_TRUNK_NATIVE,
-            port=port,
-            segmentation_id=segmentation_id)
+            port=port, 
+            segmentation_id=segmentation_id
+            )
         return self.send_commands_to_device(cmds)
 
     @netmiko_devices.check_output('unplug port')
     def delete_port(self, port, segmentation_id):
         if port not in self._get_trunk_native_ports():
-            return super(DellOS10, self).delete_port(port, segmentation_id)
-        LOG.info("Port %s is configured as a trunk-native port; clearing "
-                 "native vlan only, leaving trunk mode and allowed vlans "
-                 "intact.", port)
+            return super().delete_port(port, segmentation_id)
+        
+        # trunk-native hack
+        # warning! ignores `ngs_port_default_vlan` and `_disable_inactive_ports`
+        LOG.info("Trunk-native port %s: clear native vlan, keep trunk", port)
         cmds = self._format_commands(
             self.DELETE_PORT,
-            port=port,
-            segmentation_id=segmentation_id)
+            port=port, 
+            segmentation_id=segmentation_id
+            )
         return self.send_commands_to_device(cmds)
 
 

--- a/networking_generic_switch/tests/unit/netmiko/test_dell.py
+++ b/networking_generic_switch/tests/unit/netmiko/test_dell.py
@@ -238,6 +238,47 @@ class TestNetmikoDellOS10(test_netmiko_base.NetmikoSwitchTestBase):
             ['interface 3333', 'no switchport access vlan', 'exit']
         )
 
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device',
+                return_value="")
+    def test_plug_port_to_network_trunk_native(self, mock_exec):
+        switch = self._make_switch_device(
+            {'ngs_trunk_native_ports': 'ethernet1/1/7, ethernet1/1/8'})
+        switch.plug_port_to_network('ethernet1/1/7', 33)
+        mock_exec.assert_called_with(
+            ['interface ethernet1/1/7',
+             'switchport mode trunk',
+             'switchport access vlan 33',
+             'exit']
+        )
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device',
+                return_value="")
+    def test_plug_port_to_network_trunk_native_unaffected(self, mock_exec):
+        switch = self._make_switch_device(
+            {'ngs_trunk_native_ports': 'ethernet1/1/7'})
+        switch.plug_port_to_network('ethernet1/1/9', 33)
+        mock_exec.assert_called_with(
+            ['interface ethernet1/1/9',
+             'switchport mode access',
+             'switchport access vlan 33',
+             'exit']
+        )
+
+    @mock.patch('networking_generic_switch.devices.netmiko_devices.'
+                'NetmikoSwitch.send_commands_to_device',
+                return_value="")
+    def test_delete_port_trunk_native(self, mock_exec):
+        switch = self._make_switch_device(
+            {'ngs_trunk_native_ports': 'ethernet1/1/7'})
+        switch.delete_port('ethernet1/1/7', 33)
+        mock_exec.assert_called_with(
+            ['interface ethernet1/1/7',
+             'no switchport access vlan',
+             'exit']
+        )
+
     def test__format_commands(self):
         cmd_set = self.switch._format_commands(
             dell.DellOS10.ADD_NETWORK,


### PR DESCRIPTION
add config `ngs_trunk_native_ports`. This will leave dell os10 ports in "trunk" mode, and skip clearing tagged vlans.
This is a hack to permit bmcs to use tagged vlans.